### PR TITLE
BACKLOG-22337: Remove import version for graphql.kickstart.*

### DIFF
--- a/graphql-java-kickstart/bnd.bnd
+++ b/graphql-java-kickstart/bnd.bnd
@@ -1,4 +1,5 @@
 Export-Package: graphql.kickstart.*
 Import-Package: !lombok,\
+  graphql.kickstart.*,\
   graphql.*;version="[20.2,22)",\
   *


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22337

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

We had an issue where The specified `graphql.*` import version (in this case `[20.2,22)`) from graphql-java module was also specifying the import versions for `graphql.kickstart.*` which has a different version (in this case it's exported with 15.1.1)

Remove import versions for graphql.kickstart.* to resolve conflict issue